### PR TITLE
dist: add sd-plymouth-tpm2-totp mkinitcpio hook

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,8 +198,14 @@ helpers_SCRIPTS = dist/show-tpm2-totp
 initcpio_install_DATA = dist/initcpio/install/tpm2-totp
 initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp
 if HAVE_PLYMOUTH
-initcpio_install_DATA += dist/initcpio/install/plymouth-tpm2-totp
+initcpio_install_DATA += dist/initcpio/install/plymouth-tpm2-totp dist/initcpio/install/sd-plymouth-tpm2-totp
 initcpio_hooks_DATA += dist/initcpio/hooks/plymouth-tpm2-totp
+
+systemdsystemunit_DATA = dist/plymouth-tpm2-totp.service
+install-data-hook:
+	mkdir -p $(DESTDIR)$(systemdsystemunitdir)/sysinit.target.wants && \
+	cd $(DESTDIR)$(systemdsystemunitdir)/sysinit.target.wants && \
+	$(LN_S) ../plymouth-tpm2-totp.service
 endif # HAVE_PLYMOUTH
 endif # HAVE_MKINITCPIO
 EXTRA_DIST += dist/initcpio/hooks/tpm2-totp dist/initcpio/hooks/plymouth-tpm2-totp

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,19 @@ AM_COND_IF([HAVE_PLYMOUTH],
                   [AC_MSG_ERROR([plymouth requested but not found])])
            ])
 
+AC_ARG_WITH([udevdir],
+            AS_HELP_STRING([--with-udevdir=DIR], [udev directory]),,
+            [PKG_CHECK_VAR([with_udevdir], [udev], [udevdir],, [with_udevdir="$libdir/udev"])])
+AC_SUBST([UDEVDIR], [$with_udevdir])
+
+AC_ARG_WITH([systemdsystemunitdir],
+            AS_HELP_STRING([--with-systemdsystemunit=DIR], [systemd system unit directory]),,
+            [PKG_CHECK_VAR([with_systemdsystemunitdir], [systemd], [systemdsystemunitdir],,
+                           [with_systemdsystemunitdir="$libdir/systemd/system"])])
+AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+
+AC_CONFIG_FILES([dist/initcpio/install/sd-plymouth-tpm2-totp dist/plymouth-tpm2-totp.service])
+
 AC_ARG_ENABLE([integration],
             [AS_HELP_STRING([--enable-integration],
                             [build integration tests against TPM])],,

--- a/dist/initcpio/install/sd-plymouth-tpm2-totp.in
+++ b/dist/initcpio/install/sd-plymouth-tpm2-totp.in
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+build() {
+    local mod
+
+    if [[ $TPM_MODULES ]]; then
+        for mod in $TPM_MODULES; do
+            add_module "$mod"
+        done
+    else
+        add_all_modules /tpm/
+    fi
+
+    add_binary @PLYMOUTHPLUGINSDIR@/label.so
+    add_file "$(fc-match --format '%{file}')"
+
+    add_systemd_unit plymouth-tpm2-totp.service
+    add_file @UDEVDIR@/rules.d/*tpm-udev.rules
+    add_binary @TSS2_TCTI_DEVICE_LIBDIR@/libtss2-tcti-device.so.0
+}
+
+help() {
+    cat <<HELPEOF
+This hook uses plymouth to display a time-based one-time password (TOTP) sealed
+to a Trusted Platform Module (TPM) to ensure that the boot process has not been
+tampered with. To set this up, a secret needs to be generated first and sealed
+to the TPM using
+
+tpm2-totp generate
+
+This stores the secret in the TPM and displays it to the user so that it can
+be recorded on a different device (e.g. a TOTP app). When the hook is run, the
+TOTP is calculated and displayed using plymouth so that it can be compared with
+the output of the second device. This will only be successful and show a
+matching output if the boot process has not changed (new UEFI firmware,
+different boot loader, ...).
+
+Note that calculating the TOTP requires some entropy, which might be scarce
+directly after startup. If the boot process appears to be stuck, it might help
+to press some random keys to gather more entropy. A better alternative on modern
+processors is to enable the use of the hardware random number generator (RNG)
+by adding
+
+random.trust_cpu=on
+
+to the kernel command line.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/dist/plymouth-tpm2-totp.service.in
+++ b/dist/plymouth-tpm2-totp.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Display a TOTP during boot using Plymouth
+Requires=plymouth-start.service dev-tpm0.device
+After=plymouth-start.service dev-tpm0.device
+DefaultDependencies=no
+
+[Service]
+Type=exec
+ExecStart=@HELPERSDIR@/plymouth-tpm2-totp
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
mkinitcpio supports two different kinds of initramfs images: one with a busybox
init (HOOKS=(base udev ...)) and one with a systemd init (HOOKS=(systemd
sd-...)). Only the former supports the runtime hooks in dist/initcpio/hooks
that we use to start show-/plymouth-tpm2-totp, the latter relies on system unit
files to start programs.

This commit adds a new mkinitcpio hook "sd-plymouth-tpm2-totp" to be
used for systemd-based mkinitcpio initramfs images. It adds a systemd service
"plymouth-tpm2-totp.service" that triggers plymouth-tpm2-totp once Plymouth has
been started and /dev/tpm0 is available. While the hook itself is specific to
mkinitcpio, this service might be useful for other systemd-based initramfs
generators as well.

Unlike the other currently available hooks, this service currently does not
allow selecting a different NV index using the kernel command line. As far as I
am aware, there is no built-in way to supply arguments from the kernel command
line to systemd units, so the easiest approach might be parsing /proc/cmdline
directly in plymouth-tpm2-totp. However, this feature is out of scope for this
commit.

Signed-off-by: Jonas Witschel <diabonas@gmx.de>